### PR TITLE
Require `itsgoingd/clockwork`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "issues": "https://github.com/ptrofimov/clockwork-cli/issues"
     },
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "itsgoingd/clockwork": "1.*"
+        
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I decided just to do a quick pull request for #2. This will enable someone to add just this package to their `composer.json` and have `itsgoingd/clockwork` installed automatically as a dependency by composer.
